### PR TITLE
feat!: don't load products and apps paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,7 +6,6 @@ import (
 
 type Config struct {
 	Service     string
-	Product     string
 	Environment string
 	Region      string
 }
@@ -16,8 +15,6 @@ func (c *Config) ConsulPaths() []string {
 	return []string{
 		"global/env_vars",
 		fmt.Sprintf("global/%s/env_vars", c.Environment),
-		fmt.Sprintf("products/%s/env_vars", c.Product),               // DEPRECATED
-		fmt.Sprintf("apps/%s/%s/env_vars", c.Service, c.Environment), // DEPRECATED
 		fmt.Sprintf("services/%s/env_vars", c.Service),
 		fmt.Sprintf("services/%s/%s/env_vars", c.Service, c.Environment),
 	}
@@ -29,8 +26,6 @@ func (c *Config) VaultPaths() []string {
 		return []string{
 			"secret/global/env_vars",
 			fmt.Sprintf("secret/global/%s/env_vars", c.Environment),
-			fmt.Sprintf("secret/products/%s/env_vars", c.Product),               // DEPRECATED
-			fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment), // DEPRECATED
 			fmt.Sprintf("secret/services/%s/env_vars", c.Service),
 			fmt.Sprintf("secret/services/%s/%s/env_vars", c.Service, c.Environment),
 		}
@@ -38,8 +33,6 @@ func (c *Config) VaultPaths() []string {
 
 	return []string{
 		fmt.Sprintf("secret/global/%s/env_vars", c.Environment),
-		fmt.Sprintf("secret/products/%s/%s/env_vars", c.Product, c.Environment), // DEPRECATED
-		fmt.Sprintf("secret/apps/%s/%s/env_vars", c.Service, c.Environment),     // DEPRECATED
 		fmt.Sprintf("secret/services/%s/%s/env_vars", c.Service, c.Environment),
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -9,15 +9,12 @@ import (
 func TestConfig_ConsulPaths(t *testing.T) {
 	c := Config{
 		Service:     "foo",
-		Product:     "bar",
 		Environment: "stage",
 	}
 
 	assert.Equal(t, []string{
 		"global/env_vars",
 		"global/stage/env_vars",
-		"products/bar/env_vars",
-		"apps/foo/stage/env_vars",
 		"services/foo/env_vars",
 		"services/foo/stage/env_vars",
 	}, c.ConsulPaths())
@@ -26,15 +23,12 @@ func TestConfig_ConsulPaths(t *testing.T) {
 func TestConfig_VaultPaths(t *testing.T) {
 	c := Config{
 		Service:     "foo",
-		Product:     "bar",
 		Environment: "stage",
 	}
 
 	assert.Equal(t, []string{
 		"secret/global/env_vars",
 		"secret/global/stage/env_vars",
-		"secret/products/bar/env_vars",
-		"secret/apps/foo/stage/env_vars",
 		"secret/services/foo/env_vars",
 		"secret/services/foo/stage/env_vars",
 	}, c.VaultPaths())
@@ -43,8 +37,6 @@ func TestConfig_VaultPaths(t *testing.T) {
 	assert.Equal(t, []string{
 		"secret/global/env_vars",
 		"secret/global/prod/env_vars",
-		"secret/products/bar/env_vars",
-		"secret/apps/foo/prod/env_vars",
 		"secret/services/foo/env_vars",
 		"secret/services/foo/prod/env_vars",
 	}, c.VaultPaths())
@@ -52,8 +44,6 @@ func TestConfig_VaultPaths(t *testing.T) {
 	c.Environment = "dev"
 	assert.Equal(t, []string{
 		"secret/global/dev/env_vars",
-		"secret/products/bar/dev/env_vars",
-		"secret/apps/foo/dev/env_vars",
 		"secret/services/foo/dev/env_vars",
 	}, c.VaultPaths())
 }

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ func main() {
 
 	cfg := Config{
 		Service:     os.Getenv("SERVICE_NAME"),
-		Product:     os.Getenv("SERVICE_PRODUCT"),
 		Environment: os.Getenv("SERVICE_ENV"),
 		Region:      os.Getenv("AWS_REGION"),
 	}
@@ -35,7 +34,6 @@ func main() {
 	logger := log.With().
 		Str("env", cfg.Environment).
 		Str("service", cfg.Service).
-		Str("product", cfg.Product).
 		Str("region", cfg.Region).
 		Logger()
 


### PR DESCRIPTION
These have been deprecated for a while and we've finally been able to move everything over to either services or global instead

BREAKING CHANGE: removes loading from deprecated paths