### PR TITLE
fix: remove service name requirement

### DIFF
--- a/config.go
+++ b/config.go
@@ -12,27 +12,40 @@ type Config struct {
 
 // ConsulPaths returns the paths from Consul to load
 func (c *Config) ConsulPaths() []string {
-	return []string{
+	paths := []string{
 		"global/env_vars",
 		fmt.Sprintf("global/%s/env_vars", c.Environment),
-		fmt.Sprintf("services/%s/env_vars", c.Service),
-		fmt.Sprintf("services/%s/%s/env_vars", c.Service, c.Environment),
 	}
+
+	if c.Service != "" {
+		paths = append(
+			paths,
+			fmt.Sprintf("services/%s/env_vars", c.Service),
+			fmt.Sprintf("services/%s/%s/env_vars", c.Service, c.Environment),
+		)
+	}
+
+	return paths
 }
 
 // VaultPaths returns the paths from Vault to load
 func (c *Config) VaultPaths() []string {
-	if c.Environment == "stage" || c.Environment == "prod" {
-		return []string{
-			"secret/global/env_vars",
-			fmt.Sprintf("secret/global/%s/env_vars", c.Environment),
-			fmt.Sprintf("secret/services/%s/env_vars", c.Service),
-			fmt.Sprintf("secret/services/%s/%s/env_vars", c.Service, c.Environment),
-		}
+	isPublic := c.Environment == "stage" || c.Environment == "prod"
+	paths := []string{}
+
+	if isPublic {
+		paths = append(paths, "secret/global/env_vars")
 	}
 
-	return []string{
-		fmt.Sprintf("secret/global/%s/env_vars", c.Environment),
-		fmt.Sprintf("secret/services/%s/%s/env_vars", c.Service, c.Environment),
+	paths = append(paths, fmt.Sprintf("secret/global/%s/env_vars", c.Environment))
+
+	if c.Service != "" {
+		if isPublic {
+			paths = append(paths, fmt.Sprintf("secret/services/%s/env_vars", c.Service))
+		}
+
+		paths = append(paths, fmt.Sprintf("secret/services/%s/%s/env_vars", c.Service, c.Environment))
 	}
+
+	return paths
 }

--- a/config_test.go
+++ b/config_test.go
@@ -7,43 +7,85 @@ import (
 )
 
 func TestConfig_ConsulPaths(t *testing.T) {
-	c := Config{
-		Service:     "foo",
-		Environment: "stage",
-	}
+	t.Parallel()
 
-	assert.Equal(t, []string{
-		"global/env_vars",
-		"global/stage/env_vars",
-		"services/foo/env_vars",
-		"services/foo/stage/env_vars",
-	}, c.ConsulPaths())
+	t.Run("full config", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{Service: "foo", Environment: "stage"}
+		assert.Equal(t, []string{
+			"global/env_vars",
+			"global/stage/env_vars",
+			"services/foo/env_vars",
+			"services/foo/stage/env_vars",
+		}, c.ConsulPaths())
+	})
+
+	t.Run("no service", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{Environment: "stage"}
+		assert.Equal(t, []string{
+			"global/env_vars",
+			"global/stage/env_vars",
+		}, c.ConsulPaths())
+	})
 }
 
 func TestConfig_VaultPaths(t *testing.T) {
-	c := Config{
-		Service:     "foo",
-		Environment: "stage",
-	}
+	t.Parallel()
 
-	assert.Equal(t, []string{
-		"secret/global/env_vars",
-		"secret/global/stage/env_vars",
-		"secret/services/foo/env_vars",
-		"secret/services/foo/stage/env_vars",
-	}, c.VaultPaths())
+	t.Run("stage", func(t *testing.T) {
+		t.Parallel()
 
-	c.Environment = "prod"
-	assert.Equal(t, []string{
-		"secret/global/env_vars",
-		"secret/global/prod/env_vars",
-		"secret/services/foo/env_vars",
-		"secret/services/foo/prod/env_vars",
-	}, c.VaultPaths())
+		c := Config{Service: "foo", Environment: "stage"}
+		assert.Equal(t, []string{
+			"secret/global/env_vars",
+			"secret/global/stage/env_vars",
+			"secret/services/foo/env_vars",
+			"secret/services/foo/stage/env_vars",
+		}, c.VaultPaths())
+	})
 
-	c.Environment = "dev"
-	assert.Equal(t, []string{
-		"secret/global/dev/env_vars",
-		"secret/services/foo/dev/env_vars",
-	}, c.VaultPaths())
+	t.Run("prod", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{Service: "foo", Environment: "prod"}
+		assert.Equal(t, []string{
+			"secret/global/env_vars",
+			"secret/global/prod/env_vars",
+			"secret/services/foo/env_vars",
+			"secret/services/foo/prod/env_vars",
+		}, c.VaultPaths())
+	})
+
+	t.Run("dev", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{Service: "foo", Environment: "dev"}
+		assert.Equal(t, []string{
+			"secret/global/dev/env_vars",
+			"secret/services/foo/dev/env_vars",
+		}, c.VaultPaths())
+	})
+
+	t.Run("no service", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{Environment: "prod"}
+
+		assert.Equal(t, []string{
+			"secret/global/env_vars",
+			"secret/global/prod/env_vars",
+		}, c.VaultPaths())
+	})
+
+	t.Run("no service dev", func(t *testing.T) {
+		t.Parallel()
+
+		c := Config{Environment: "dev"}
+		assert.Equal(t, []string{
+			"secret/global/dev/env_vars",
+		}, c.VaultPaths())
+	})
 }

--- a/main.go
+++ b/main.go
@@ -21,14 +21,10 @@ func main() {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
-	cfg := Config{
+	cfg := &Config{
 		Service:     os.Getenv("SERVICE_NAME"),
 		Environment: os.Getenv("SERVICE_ENV"),
 		Region:      os.Getenv("AWS_REGION"),
-	}
-
-	if cfg.Service == "" {
-		log.Fatal().Msg("SERVICE_NAME cannot be blank")
 	}
 
 	if cfg.Environment == "" {
@@ -76,7 +72,7 @@ func main() {
 	os.Exit(run(os.Args[1], os.Args[2:], env.Environ(), logger))
 }
 
-func loadConsul(addr string, c Config, l zerolog.Logger) Dict {
+func loadConsul(addr string, c *Config, l zerolog.Logger) Dict {
 	l.Debug().Msg("Loading values from Consul")
 
 	client, err := NewConsul(addr)
@@ -92,7 +88,7 @@ func loadConsul(addr string, c Config, l zerolog.Logger) Dict {
 	return loadValues(client, l, paths)
 }
 
-func loadVault(ctx context.Context, addr string, c Config, l zerolog.Logger) Dict {
+func loadVault(ctx context.Context, addr string, c *Config, l zerolog.Logger) Dict {
 	l.Debug().Msg("Loading values from Vault")
 
 	client, err := NewVault(addr, c.Region)


### PR DESCRIPTION
There's a lot of services that don't define any of these inputs locally and are causing a bunch of issues. Remove the service name requirement and don't load those paths if there is no service.