### PR TITLE
feat: log when SERVICE_NAME is not set

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,8 +27,12 @@ func main() {
 		Region:      os.Getenv("AWS_REGION"),
 	}
 
+	if cfg.Service == "" {
+		log.Warn().Msg("SERVICE_NAME is not set, will not load service values")
+	}
+
 	if cfg.Environment == "" {
-		log.Warn().Msg("SERVICE_ENV is blank, defaulting to dev")
+		log.Warn().Msg("SERVICE_ENV is not set, defaulting to dev")
 		cfg.Environment = "dev"
 	}
 


### PR DESCRIPTION
If service name is not set, it will not load service paths, does this quietly. Add a log message to call out that's what's happening