### PR TITLE
chore(upgrade-aws-cli): upgrade aws cli to 2.15.25

### DIFF
--- a/scripts/awscli.sh
+++ b/scripts/awscli.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-AWSCLI_VERSION="${AWSCLI_VERSION:-2.13.28}"
+AWSCLI_VERSION="${AWSCLI_VERSION:-2.15.25}"
 
 missing=""
 command -v curl >/dev/null || missing="${missing} curl"


### PR DESCRIPTION
Upgrading aws cli to the most recent version 2.15.25