### PR TITLE
refactor(logging)!: switch to slog for logging

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,12 +2,38 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 )
 
 type Config struct {
 	Service     string
 	Environment string
 	Region      string
+}
+
+// NewFromEnv creates a new Config from environment variables and defaults
+func NewFromEnv() *Config {
+	cfg := &Config{
+		Service:     os.Getenv("SERVICE_NAME"),
+		Environment: os.Getenv("SERVICE_ENV"),
+		Region:      os.Getenv("AWS_REGION"),
+	}
+
+	if cfg.Service == "" {
+		slog.Warn("SERVICE_NAME is not set, will not load service values")
+	}
+
+	if cfg.Environment == "" {
+		slog.Warn("SERVICE_ENV is not set, defaulting to dev")
+		cfg.Environment = "dev"
+	}
+
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+
+	return cfg
 }
 
 // ConsulPaths returns the paths from Consul to load

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/hashicorp/vault/api v1.12.0
 	github.com/hashicorp/vault/api/auth/aws v0.6.0
 	github.com/hashicorp/vault/api/auth/kubernetes v0.6.0
-	github.com/rs/zerolog v1.32.0
 	github.com/samber/lo v1.39.0
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -49,7 +49,6 @@ github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4r
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -70,7 +69,6 @@ github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -226,9 +224,6 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
-github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
@@ -318,7 +313,6 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,40 @@
+package main
+
+import "log/slog"
+
+// structuredError is an error that can be logged with additional data
+type structuredError struct {
+	err  error
+	args []any
+}
+
+// NewStructuredError returns a new structure error that will be logged with additional data
+func serror(err error, args ...any) *structuredError {
+	return &structuredError{err: err, args: args}
+}
+
+func (e *structuredError) Error() string {
+	return e.err.Error()
+}
+
+func (e *structuredError) Unwrap() error {
+	return e.err
+}
+
+// LogValue returns a structured log value for use with slog
+func (e structuredError) LogValue() slog.Value {
+	args := make([]slog.Attr, 0, (len(e.args)/2)+1)
+	args = append(args, slog.String(slog.MessageKey, e.Error()))
+
+	var c interface{}
+	for _, a := range e.args {
+		if c == nil {
+			c = a
+			continue
+		}
+		args = append(args, slog.Any(c.(string), a))
+		c = nil
+	}
+
+	return slog.GroupValue(args...)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructuredError(t *testing.T) {
+	wrapped := fmt.Errorf("test error: %w", os.ErrNotExist)
+	err := serror(wrapped, "foo", "bar")
+
+	require.ErrorContains(t, err, "test error")
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	l, log := testLogger()
+	l.Error("test", "error", err)
+	assert.Contains(t, log.String(), `"error":{"msg":"test error: file does not exist","foo":"bar"}`)
+}
+
+func testLogger() (*slog.Logger, *bytes.Buffer) {
+	log := &bytes.Buffer{}
+	return slog.New(slog.NewJSONHandler(log, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == "time" {
+				a.Value = slog.StringValue("test-time")
+			}
+			return a
+		},
+	})), log
+}

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/rs/zerolog"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
 
 type (
 	Dict map[string]string
@@ -11,19 +15,19 @@ type (
 	}
 )
 
-func loadValues(c Client, l zerolog.Logger, paths []string) Dict {
+func loadValues(ctx context.Context, c Client, l *slog.Logger, paths []string) (Dict, error) {
 	values := map[string]string{}
 	for _, path := range paths {
-		l.Debug().Str("path", path).Msg("Loading values")
+		l.DebugContext(ctx, "Loading values", "path", path)
 
 		kv, err := c.Load(path)
 		if err != nil {
-			l.Fatal().Err(err).Str("path", path).Msg("Could not load values")
+			return values, serror(fmt.Errorf("Could not load values: %w", err), "path", path)
 		}
 
 		for k, v := range kv {
 			values[k] = v
 		}
 	}
-	return values
+	return values, nil
 }


### PR DESCRIPTION
Go now includes a nice way to do structured logs, including JSON. Use that instead of a third party module.

BREAKING CHANGE: log format will change a little bit