### PR TITLE
fix: forward signals to child process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add folks who need to be notified on PRs to this repo:
-* @articulate/platform
+* @articulate/devex-sre


### PR DESCRIPTION
Applications are expecting to get SIGTERM to handle any shutdown. This currently doesn't forward signals and will just terminate the child process.