### PR TITLE
fix: remove set group pid

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,9 +151,6 @@ func run(ctx context.Context, name string, args, env []string, l *slog.Logger) i
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
-	if name != "bash" && name != "sh" && name != "zsh" && name != "fish" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	}
 
 	if err := cmd.Start(); err != nil {
 		l.ErrorContext(ctx, "Could not start command", "error", err, "cmd", cmd.String())
@@ -182,7 +179,7 @@ func run(ctx context.Context, name string, args, env []string, l *slog.Logger) i
 	go func() {
 		<-exitch
 		time.Sleep(killWait)
-		l.DebugContext(ctx, "Terminating unrespnsive process", "cmd", cmd.String())
+		l.WarnContext(ctx, "Terminating unrespnsive process", "cmd", cmd.String())
 		cancel()
 	}()
 


### PR DESCRIPTION
When running this directly without this option, some signals get sent twice. However, this is usually ran through Docker so it won't get duplicate signals. There are a lot of programs that are having issues with the group pid being set, so completely remove it