### PR TITLE
feat: handle zombie processes

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,7 +65,14 @@ func main() {
 		go reapChildren(ctx, logger)
 	}
 
-	os.Exit(run(ctx, os.Args[1], os.Args[2:], env.Environ(), logger))
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	if cmd == "yarn" {
+		logger.WarnContext(ctx, "yarn is not recommended. You might see unexpected behavior. Use node or npm instead.")
+	}
+
+	os.Exit(run(ctx, cmd, args, env.Environ(), logger))
 }
 
 func loadEnvVars(ctx context.Context, cfg *Config, l *slog.Logger) (*EnvMap, error) {

--- a/main.go
+++ b/main.go
@@ -192,5 +192,8 @@ func run(ctx context.Context, name string, args, env []string, l *slog.Logger) i
 		return 3
 	}
 
+	if code := cmd.ProcessState.ExitCode(); code != -1 {
+		return code
+	}
 	return 0
 }


### PR DESCRIPTION
The process running PID 1 (which this is intended to be) has some additional responsibilities. First it needs to send signals, which was handled recently, but this improves upon. Secondly it needs to reap zombie processes, which is added here.

This now handles all signals and not just a subset of signals.

We found some issues while running yarn while setting pgid, so that's also not being set along with running shells. Warn on yarn usage since it could cause unexpected issues.