### PR TITLE
fix(validate): include missing env vars in error message

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/samber/lo"
 )
@@ -81,7 +82,7 @@ func validate(ctx context.Context, c *Config, e *EnvMap, l *slog.Logger) error {
 
 	if len(req) != 0 {
 		l.ErrorContext(ctx, "Missing required environment variables", "env_vars", req)
-		return ErrMissingEnvVars
+		return fmt.Errorf("%w: %s", ErrMissingEnvVars, strings.Join(req, ", "))
 	}
 
 	return nil


### PR DESCRIPTION
When missing require env vars, the final error message doesn't include any indication of what's missing. We do log in another line the list, but has lead to confusion when debugging