### PR TITLE
feat(validate): add products field to dependencies

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	Service           string
 	Environment       string
+	Product           string
 	Region            string
 	ServiceDefinition string
 	SkipValidation    bool
@@ -20,6 +21,7 @@ func NewFromEnv() *Config {
 	cfg := &Config{
 		Service:           os.Getenv("SERVICE_NAME"),
 		Environment:       os.Getenv("SERVICE_ENV"),
+		Product:           os.Getenv("SERVICE_PRODUCT"),
 		Region:            os.Getenv("AWS_REGION"),
 		ServiceDefinition: os.Getenv("SERVICE_DEFINITION"),
 		SkipValidation:    false,

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 )
 
@@ -14,6 +15,7 @@ type Config struct {
 	Region            string
 	ServiceDefinition string
 	SkipValidation    bool
+	Program           string
 }
 
 // NewFromEnv creates a new Config from environment variables and defaults
@@ -25,6 +27,7 @@ func NewFromEnv() *Config {
 		Region:            os.Getenv("AWS_REGION"),
 		ServiceDefinition: os.Getenv("SERVICE_DEFINITION"),
 		SkipValidation:    false,
+		Program:           "docker-bootstrap",
 	}
 
 	if s, err := strconv.ParseBool(os.Getenv("BOOTSTRAP_SKIP_VALIDATION")); err == nil {
@@ -46,6 +49,10 @@ func NewFromEnv() *Config {
 
 	if cfg.ServiceDefinition == "" {
 		cfg.ServiceDefinition = "service.json"
+	}
+
+	if ex, err := os.Executable(); err == nil {
+		cfg.Program = filepath.Base(ex)
 	}
 
 	return cfg

--- a/main.go
+++ b/main.go
@@ -33,7 +33,12 @@ func main() {
 	}
 
 	cfg := NewFromEnv()
-	logger = logger.With("env", cfg.Environment, "service", cfg.Service, "region", cfg.Region)
+	logger = logger.With(
+		slog.String("env", cfg.Environment),
+		slog.String("service", cfg.Service),
+		slog.String("product", cfg.Product),
+		slog.String("region", cfg.Region),
+	)
 	slog.SetDefault(logger)
 
 	if len(os.Args) < 2 {

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 		slog.String("service", cfg.Service),
 		slog.String("product", cfg.Product),
 		slog.String("region", cfg.Region),
+		slog.String("program", cfg.Program),
 	)
 	slog.SetDefault(logger)
 

--- a/validate.go
+++ b/validate.go
@@ -26,16 +26,17 @@ type (
 		Partial bool `json:"-"`
 	}
 	dependencyInner struct {
-		Key     string   `json:"key"`
-		Regions []string `json:"regions"`
+		Key      string   `json:"key"`
+		Regions  []string `json:"regions"`
+		Products []string `json:"products"`
 	}
 )
 
 var ErrMissingEnvVars = errors.New("missing required environment variables")
 
 // Required returns true if the dependency is required for the given region
-func (d *dependency) Required(region string) bool {
-	return d.Regions == nil || lo.Contains(d.Regions, region)
+func (d *dependency) Required(product, region string) bool {
+	return (d.Products == nil || lo.Contains(d.Products, product)) && (d.Regions == nil || lo.Contains(d.Regions, region))
 }
 
 // UnmarshalJSON handles the dependency being a string or an object
@@ -91,7 +92,7 @@ func validate(ctx context.Context, c *Config, e *EnvMap, l *slog.Logger) error {
 func missing(deps []dependency, c *Config, e *EnvMap) []string {
 	res := []string{}
 	for _, d := range deps {
-		if !d.Required(c.Region) {
+		if !d.Required(c.Product, c.Region) {
 			continue
 		}
 


### PR DESCRIPTION
Allow different dependencies in different products. Requires SERVICE_PRODUCT to be set.

To help determine where the log is coming from, add a program field to logs