### PR TITLE
style: fix lint issues with latest golangci-lint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# Add folks who need to be notified on PRs to this repo:
-* @articulate/devex-sre
+* @articulate/devex

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -9,7 +9,7 @@ repos:
       - id: check-yaml
       - id: no-commit-to-branch
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.56.1
+    rev: v1.62.2
     hooks:
       - id: golangci-lint
   - repo: https://github.com/syntaqx/git-hooks

--- a/logger.go
+++ b/logger.go
@@ -22,7 +22,7 @@ func (e *structuredError) Unwrap() error {
 }
 
 // LogValue returns a structured log value for use with slog
-func (e structuredError) LogValue() slog.Value {
+func (e *structuredError) LogValue() slog.Value {
 	args := make([]slog.Attr, 0, (len(e.args)/2)+1)
 	args = append(args, slog.String(slog.MessageKey, e.Error()))
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -34,9 +34,10 @@ func TestLoadValues(t *testing.T) {
 		"bar": "baz",
 	}, d)
 
-	assert.Equal(t, []byte(`{"time":"test-time","level":"DEBUG","msg":"Loading values","path":"foo"}
+	//nolint:testifylint
+	assert.Equal(t, `{"time":"test-time","level":"DEBUG","msg":"Loading values","path":"foo"}
 {"time":"test-time","level":"DEBUG","msg":"Loading values","path":"bar"}
-`), log.Bytes())
+`, log.String())
 
 	m.AssertExpectations(t)
 }
@@ -51,8 +52,7 @@ func TestLoadValues_Error(t *testing.T) {
 	require.ErrorContains(t, err, "Could not load values: test error")
 	assert.Equal(t, Dict{}, d)
 
-	assert.Equal(t, []byte(`{"time":"test-time","level":"DEBUG","msg":"Loading values","path":"none"}
-`), log.Bytes())
+	assert.JSONEq(t, `{"time":"test-time","level":"DEBUG","msg":"Loading values","path":"none"}`, log.String())
 
 	m.AssertExpectations(t)
 }


### PR DESCRIPTION
Upgrade per-commit versions to latest to catch new linter checks