### PR TITLE
build(awscli): install groff and less

### DIFF
--- a/scripts/awscli.sh
+++ b/scripts/awscli.sh
@@ -8,22 +8,18 @@ command -v curl >/dev/null || missing="${missing} curl"
 command -v unzip >/dev/null || missing="${missing} unzip"
 test -d /etc/ssl/certs || missing="${missing} ca-certificates"
 
-if [ "$missing" != "" ]; then
-    apt-get update -qq
-    # shellcheck disable=SC2086
-    apt-get install --yes --no-install-recommends $missing
-fi
+apt-get update -qq
+# shellcheck disable=SC2086
+apt-get install --yes --no-install-recommends $missing less groff
 
 curl -s "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m)-${AWSCLI_VERSION}.zip" -o /tmp/awscliv2.zip
 unzip -q -d /tmp /tmp/awscliv2.zip
 /tmp/aws/install "$@"
 rm -rf /tmp/aws /tmp/awscliv2 /tmp/awscliv2.zip
 
-if [ "$missing" != "" ]; then
-    # shellcheck disable=SC2086
-    apt-get remove --yes $missing
-    apt-get clean
-    apt-get autoclean
-    apt-get autoremove --yes --purge
-    rm -rf /var/lib/apt/lists /var/cache/apt/archives /usr/share/doc /root/.cache/
-fi
+# shellcheck disable=SC2086
+test -z "$missing" || apt-get remove --yes $missing
+apt-get clean
+apt-get autoclean
+apt-get autoremove --yes --purge
+rm -rf /var/lib/apt/lists /var/cache/apt/archives /usr/share/doc /root/.cache/


### PR DESCRIPTION
These tools are needed when using commands like help