### PR TITLE
fix(ci): pr-title now must match conventional commit

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,10 @@
+name: PR Checks
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  title-check:
+    uses: articulate/devex-sre/.github/workflows/conventional-commit-pr-title.yaml@main
+    secrets: inherit


### PR DESCRIPTION
The last PR didn't kick off a release, and realized we'd missed the auto-gen'd github commit didn't match conventional commits. Fixed it here, but also marking this as a `fix` so the last commit gets built as well.