### PR TITLE
Change settings to unpack and dynamically link libraries

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,17 +8,17 @@ builds:
       - linux
     goarch:
       - amd64
-      - arm64
     flags:
       - -trimpath
       - -mod=readonly
+      - -tags=cgo
     ldflags:
       - -s -w
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
 upx:
-  - enabled: true
-    brute: true
+  - enabled: false
+    brute: false
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
     format: binary

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,21 +4,31 @@ before:
     - go mod tidy
     - go generate ./...
 builds:
-  - goos:
+  - id: bootstrap-amd64
+    goos:
       - linux
     goarch:
       - amd64
-    flags:
-      - -trimpath
-      - -mod=readonly
-      - -tags=cgo
     ldflags:
-      - -s -w
+      - "-s -w -extldflags '-Wl,-rpath,$ORIGIN'"
     env:
       - CGO_ENABLED=1
-upx:
-  - enabled: false
-    brute: false
+      - CC=gcc
+      - CXX=g++
+    
+  - id: bootstrap-arm64
+    goos:
+      - linux
+    goarch:
+      - arm64
+    ldflags:
+      - "-s -w -extldflags '-Wl,-rpath,$ORIGIN'"
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+      - CGO_LDFLAGS="-L/usr/aarch64-linux-gnu/lib -Wl,--sysroot=/usr/aarch64-linux-gnu"
+      - CGO_CFLAGS="--sysroot=/usr/aarch64-linux-gnu"
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
     format: binary


### PR DESCRIPTION
Our falcon sensor has been detecting this as a malicious file due to it being packed and statically linked. These changes to `.goreleaser.yaml` reflect these changes.

### Note:
In order to compile an arm64 binary on an amd64 machine, we'll need to install a few additional packages:

```
sudo apt update
sudo apt install -y \
  gcc-aarch64-linux-gnu \
  g++-aarch64-linux-gnu \
  binutils-aarch64-linux-gnu \
  libc6-arm64-cross \
  libc6-dev-arm64-cross

```

This will install the gcc arm64 cross compiler and the arm64 standard libraries