### PR TITLE
fix(goreleaser): disable upx

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,9 +16,6 @@ builds:
       - -s -w
     env:
       - CGO_ENABLED=0
-upx:
-  - enabled: true
-    brute: true
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}'
     format: binary


### PR DESCRIPTION
This is causing some issues with our process scanner, so remove it and use the unpacked binary