### PR TITLE
fix(env): escape newlines in environment variable values

### DIFF
--- a/env.go
+++ b/env.go
@@ -57,7 +57,7 @@ func (e *EnvMap) Environ() []string {
 	})
 
 	return lo.MapToSlice(env, func(k string, v string) string {
-		return fmt.Sprintf("%s=%s", k, strings.ReplaceAll(v, "\n", "\\n"))
+		return fmt.Sprintf("%s=%s", k, v)
 	})
 }
 

--- a/env_test.go
+++ b/env_test.go
@@ -25,12 +25,6 @@ func TestEnvMap(t *testing.T) {
 	e.Add("DOCKER_CONSUL_BOOTSTRAP_EXPAND_ONE", "foo-${DOCKER_CONSUL_BOOTSTRAP_TEST_FOO}-bar")
 	e.Add("DOCKER_CONSUL_BOOTSTRAP_EXPAND_TWO", "foo-${DOCKER_CONSUL_BOOTSTRAP_TEST_BAZ}-baz")
 	e.Add("  ", "test-empty")
-	e.Add("DOCKER_CONSUL_BOOTSTRAP_NEWLINE_ESCAPED", "foo\\n\\nbar")
-	e.Add("DOCKER_CONSUL_BOOTSTRAP_NEWLINE", `foo
-bar
-baz
-
-test`)
 
 	assert.ElementsMatch(t, []string{
 		"DOCKER_CONSUL_BOOTSTRAP_TEST_TEST=testing",
@@ -39,7 +33,5 @@ test`)
 		"DOCKER_CONSUL_BOOTSTRAP_TEST_BAZ=bar",
 		"DOCKER_CONSUL_BOOTSTRAP_EXPAND_ONE=foo-ignore-bar",
 		"DOCKER_CONSUL_BOOTSTRAP_EXPAND_TWO=foo-bar-baz",
-		"DOCKER_CONSUL_BOOTSTRAP_NEWLINE_ESCAPED=foo\\n\\nbar",
-		"DOCKER_CONSUL_BOOTSTRAP_NEWLINE=foo\\nbar\\nbaz\\n\\ntest",
 	}, e.Environ())
 }


### PR DESCRIPTION
Reverts articulate/docker-bootstrap#300