### PR TITLE
chore(goreleaser): update config to publish prereleases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,7 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
 version: 2
+project_name: docker-bootstrap
 before:
   hooks:
     - go mod tidy
@@ -19,12 +22,16 @@ builds:
       - CGO_ENABLED=0
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    format: binary
+    formats:
+      - binary
 checksum:
   name_template: "checksums.txt"
 snapshot:
   version_template: "{{ incpatch .Version }}-next"
+changelog:
+  disable: true # Use changelog from release-please
 release:
+  prerelease: auto
   use_existing_draft: true
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+git:
+  prerelease_suffix: "-"


### PR DESCRIPTION
Make sure beta releases are marked as prereleases.

Fix archives.format deprecation