### PR TITLE
feat: add PR triage workflow

### DIFF
--- a/.github/workflows/pr-triage.yaml
+++ b/.github/workflows/pr-triage.yaml
@@ -1,0 +1,12 @@
+name: Pull Request Triage
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  pr-triage:
+    uses: articulate/shipping/.github/workflows/pr-triage.lock.yml@v1
+    secrets: inherit
+    with:
+      dry_run: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pr-triage.yaml` consumer workflow per the [Agent Bootstrap for Code Review Triage ADR](https://www.notion.so/articulate-global/Agent-Bootstrap-for-Code-Review-Triage-350cb369d49880c8b755cba4dd9e99a5)
- Runs in **dry-run mode** — the agent posts a triage comment but does not assign reviewers
- No `.art/agents/PR_TRIAGE.md` supplement: small Vault/Consul bootstrap utility owned entirely by `@articulate/devex`; CODEOWNERS routing is sufficient

## Test plan
- [ ] CI green
- [ ] On merge, the next PR opened in this repo should receive a triage comment with reviewer/risk rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)