### PR TITLE
ci(update-awscli): use GitHub App token to create PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @articulate/devex
 
-# Allow Botzo to approve dependency bumps (and related updates)
+# Allow Botzo to approve dependency bumps
 go.*                @articulate/devex @botzo
 /.github/workflows/ @articulate/devex @botzo
+/scripts/awscli.sh  @articulate/devex @botzo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/create-github-app-token@v3
         id: token

--- a/.github/workflows/update-awscli.yaml
+++ b/.github/workflows/update-awscli.yaml
@@ -8,9 +8,6 @@ on:
 jobs:
   update:
     runs-on: ubuntu-slim
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
       - name: Determine latest AWS CLI 2.x version
@@ -39,12 +36,22 @@ jobs:
             }
             core.setOutput('version', latest);
       - name: Update awscli.sh
+        id: update
         env:
           VERSION: ${{ steps.awscli.outputs.version }}
         run: |
           sed -i -E "s/(AWSCLI_VERSION:-)[0-9.]+/\1${VERSION}/" scripts/awscli.sh
-      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+          echo "changed=$(git diff --quiet && echo false || echo true)" >> "$GITHUB_OUTPUT"
+      - if: steps.update.outputs.changed == 'true'
+        uses: actions/create-github-app-token@v3
+        id: token
         with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_PRIVATE_KEY }}
+      - if: steps.update.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        with:
+          token: ${{ steps.token.outputs.token }}
           branch: update-awscli
           commit-message: "chore: bump AWSCLI_VERSION to ${{ steps.awscli.outputs.version }}"
           sign-commits: true


### PR DESCRIPTION
The update awscli PR was being opened by GitHub, which doesn't auto-run any workflows and ends up skipping our auto-merge workflow as well. Migrate to a GitHub App token which will trigger workflows correctly.

Update CODEOWNERS to allow Botzo to approve and merge awscli updates.

Migrate the release setup job to use ubuntu-slim